### PR TITLE
move API key into configuration form

### DIFF
--- a/newtab.html
+++ b/newtab.html
@@ -15,7 +15,6 @@
       <aside id="praise"></aside>
     </div>
     <script src="marked.min.js"></script>
-    <script src="config.js"></script>
     <script src="newtab.js"></script>
   </body>
 </html>

--- a/newtab.js
+++ b/newtab.js
@@ -43,22 +43,22 @@ function getRandomInt(max) {
   return Math.floor(Math.random() * Math.floor(max));
 }
 
-function setPraise() {
-  chrome.storage.local.get('praiseMarkdown').then((result) => {
-    const praises = result.praiseMarkdown;
-    const randomIndex = getRandomInt(praises.length);
-    const praise = praises[randomIndex];
+async function setPraise() {
+  const result = await chrome.storage.local.get('praiseMarkdown');
 
-    const praiseHtml = marked.parse(praise);
+  const praises = result.praiseMarkdown;
+  const randomIndex = getRandomInt(praises.length);
+  const praise = praises[randomIndex];
 
-    const praisePara = document.querySelector('#praise');
-    praisePara.innerHTML = praiseHtml;
-  });
+  const praiseHtml = marked.parse(praise);
+
+  const praisePara = document.querySelector('#praise');
+  praisePara.innerHTML = praiseHtml;
 }
 
 (async () => {
   setCurrentTime();
-  setPraise();
+  await setPraise();
   setInterval(setCurrentTime, 1000);
   await setBackgroundImage();
 })();

--- a/newtab.js
+++ b/newtab.js
@@ -1,11 +1,11 @@
 'use strict';
 
-const { unsplashClientId } = window;
-
 async function getRandomUnsplashImageURL() {
+  const { unsplashAPIKey } = await chrome.storage.local.get('unsplashAPIKey');
+  console.log(unsplashAPIKey);
   const collectionId = '11649432';
   const orientation = 'landscape';
-  const apiEndpoint = `https://api.unsplash.com/photos/random/?client_id=${unsplashClientId}&collections=${collectionId}&orientation=${orientation}`;
+  const apiEndpoint = `https://api.unsplash.com/photos/random/?client_id=${unsplashAPIKey}&collections=${collectionId}&orientation=${orientation}`;
 
   const response = await fetch(apiEndpoint);
   const image = await response.json();

--- a/newtab.js
+++ b/newtab.js
@@ -2,7 +2,6 @@
 
 async function getRandomUnsplashImageURL() {
   const { unsplashAPIKey } = await chrome.storage.local.get('unsplashAPIKey');
-  console.log(unsplashAPIKey);
   const collectionId = '11649432';
   const orientation = 'landscape';
   const apiEndpoint = `https://api.unsplash.com/photos/random/?client_id=${unsplashAPIKey}&collections=${collectionId}&orientation=${orientation}`;

--- a/popup/default.html
+++ b/popup/default.html
@@ -3,17 +3,31 @@
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
-    <h1>Praise editor</h1>
-    <p>Enter or edit some praise markdown below.</p>
+    <h1>You're Doing A Good Job!</h1>
+    <h2>Configuration</h2>
     <form>
-      <p>
-        <label for="praiseMarkdown">Praise Markdown</label>
-        <textarea name="praiseMarkdown" id="praiseMarkdown"></textarea>
-      </p>
-      <p>
-        <button type="reset">Reset</button>
+      <div>
         <button type="submit">Update</button>
-      </p>
+      </div>
+      <fieldset>
+        <legend>Unsplash API key</legend>
+        <p>Enter an Unsplash API access key, to see beautiful images.</p>
+        <div>
+          <label for="unsplashKey">API access key</label>
+          <input type="text" name="unsplashKey" id="unsplashKey" />
+        </div>
+      </fieldset>
+      <fieldset>
+        <legend>Praise markdown</legend>
+        <p>
+          Enter praise markdown below. Individual praises should be separated by
+          `---`.
+        </p>
+        <div>
+          <label for="praiseMarkdown">Praise Markdown</label>
+          <textarea name="praiseMarkdown" id="praiseMarkdown"></textarea>
+        </div>
+      </fieldset>
     </form>
     <script src="praiseForm.js"></script>
   </body>

--- a/popup/default.html
+++ b/popup/default.html
@@ -14,7 +14,7 @@
         <p>Enter an Unsplash API access key, to see beautiful images.</p>
         <div>
           <label for="unsplashAPIKey">API access key</label>
-          <input type="text" name="unsplashAPIKey" id="unsplashAPIKey" />
+          <input type="password" name="unsplashAPIKey" id="unsplashAPIKey" />
         </div>
       </fieldset>
       <fieldset>

--- a/popup/default.html
+++ b/popup/default.html
@@ -13,8 +13,8 @@
         <legend>Unsplash API key</legend>
         <p>Enter an Unsplash API access key, to see beautiful images.</p>
         <div>
-          <label for="unsplashKey">API access key</label>
-          <input type="text" name="unsplashKey" id="unsplashKey" />
+          <label for="unsplashAPIKey">API access key</label>
+          <input type="text" name="unsplashAPIKey" id="unsplashAPIKey" />
         </div>
       </fieldset>
       <fieldset>

--- a/popup/praiseForm.js
+++ b/popup/praiseForm.js
@@ -4,27 +4,28 @@ const handleConfigSubmit = (event) => {
   const praiseString = praiseElement.value;
   const praiseArray = praiseString.split('\n\n---\n\n');
 
-  // TODO: convert markdown to html
+  const unsplashKey = document.querySelector('#unsplashKey').value;
 
-  chrome.storage.local.set({ praiseMarkdown: praiseArray });
+  chrome.storage.local.set({ unsplashKey, praiseMarkdown: praiseArray });
 };
 
-function readValue() {
-  chrome.storage.local.get('praiseMarkdown').then((result) => {
-    console.log('Value currently is ' + JSON.stringify(result, null, 2));
-    const praiseElement = document.querySelector('#praiseMarkdown');
-    praiseElement.value = result.praiseMarkdown.join('\n\n---\n\n');
-  });
+function readValues() {
+  chrome.storage.local
+    .get(['unsplashKey', 'praiseMarkdown'])
+    .then(({ unsplashKey, praiseMarkdown }) => {
+      const unsplashKeyElement = document.querySelector('#unsplashKey');
+      unsplashKeyElement.value = unsplashKey;
+
+      const praiseElement = document.querySelector('#praiseMarkdown');
+      praiseElement.value = praiseMarkdown.join('\n\n---\n\n');
+    });
 }
 
 const initializeForm = () => {
   const [form] = document.getElementsByTagName('form');
-  // form.addEventListener("reset", handleConfigReset);
   form.addEventListener('submit', handleConfigSubmit);
-  // setFormValues();
 
-  // setListItems();
-  readValue();
+  readValues();
 };
 
 window.addEventListener('load', initializeForm);

--- a/popup/praiseForm.js
+++ b/popup/praiseForm.js
@@ -4,17 +4,17 @@ const handleConfigSubmit = (event) => {
   const praiseString = praiseElement.value;
   const praiseArray = praiseString.split('\n\n---\n\n');
 
-  const unsplashKey = document.querySelector('#unsplashKey').value;
+  const unsplashAPIKey = document.querySelector('#unsplashAPIKey').value;
 
-  chrome.storage.local.set({ unsplashKey, praiseMarkdown: praiseArray });
+  chrome.storage.local.set({ unsplashAPIKey, praiseMarkdown: praiseArray });
 };
 
 function readValues() {
   chrome.storage.local
-    .get(['unsplashKey', 'praiseMarkdown'])
-    .then(({ unsplashKey, praiseMarkdown }) => {
-      const unsplashKeyElement = document.querySelector('#unsplashKey');
-      unsplashKeyElement.value = unsplashKey;
+    .get(['unsplashAPIKey', 'praiseMarkdown'])
+    .then(({ unsplashAPIKey, praiseMarkdown }) => {
+      const unsplashKeyElement = document.querySelector('#unsplashAPIKey');
+      unsplashKeyElement.value = unsplashAPIKey;
 
       const praiseElement = document.querySelector('#praiseMarkdown');
       praiseElement.value = praiseMarkdown.join('\n\n---\n\n');

--- a/popup/style.css
+++ b/popup/style.css
@@ -1,3 +1,30 @@
 #praiseMarkdown {
   height: 300px;
 }
+
+form {
+  width: 400px;
+}
+
+label {
+  margin: 0;
+  display: block;
+  height: 0;
+  visibility: hidden;
+}
+
+input, textarea {
+  width: 100%;
+}
+
+fieldset {
+  margin: 20px 0;
+}
+
+fieldset p {
+  font-style: italic;
+}
+
+legend {
+  font-weight: bold;
+}


### PR DESCRIPTION
Moves the API key into the configuration form, instead of a gitignored file. 

## Why?

If I install this thing in a new browser, I don't want to have to dig into the file system to set the key. 

## What's it look like?

<img width="500" alt="image" src="https://github.com/pepopowitz/doing-a-good-job/assets/1627089/8e1281ae-937e-4040-9c5b-02d4b9450bf7">
