### PR TITLE
delay load of praise

### DIFF
--- a/style.css
+++ b/style.css
@@ -42,12 +42,20 @@ p {
 }
 
 #content aside {
+  backdrop-filter: blur(2px);
   align-self: center;
   display: flex;
   flex-direction: column;
   max-width: 500px;
   background-color: #33333366;
   padding: 1em;
+  animation: fadein 20s;
+}
+
+@keyframes fadein {
+  0% { opacity: 0 }
+  95% { opacity: 0 }
+  100% { opacity: 1}
 }
 
 #content h2 {


### PR DESCRIPTION
While I love this app, I also feel shame in needing this praise to feel better about myself. This PR delays the appearance of the praise by about 19 seconds, so that if I'm sharing a screen, I can probably go to my target URL before it shows up. 

What it looks like: 


https://github.com/pepopowitz/doing-a-good-job/assets/1627089/0cfdb214-8ff2-4153-90d0-c2c49d01e41b

## Alternatives considered

I thought about requiring some kind of user action for the praise to appear. I chose the time delay option in this PR because I could do it without any JavaScript. If the time delay proves to not be adequate, I might switch to toggling the appearance based on some user action.

